### PR TITLE
Add support for overriding SQL connection type

### DIFF
--- a/SQLLite/SQLLite.csproj
+++ b/SQLLite/SQLLite.csproj
@@ -37,6 +37,7 @@
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite, Version=1.0.109.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\System.Data.SQLite.Core.1.0.109.1\lib\net46\System.Data.SQLite.dll</HintPath>

--- a/SQLLite/SQLLite/SQLConnection.cs
+++ b/SQLLite/SQLLite/SQLConnection.cs
@@ -37,6 +37,7 @@ namespace SQLLiteExtensions
         protected Thread owningThread;          // tracing who owns the thread to prevent cross thread ops
         protected static List<SQLExtConnection> openConnections = new List<SQLExtConnection>(); // debugging mostly, track connections
         protected static DbProviderFactory DbFactory = GetSqliteProviderFactory();  
+        protected static string DbConnectionString = null;
         public string DBFile { get; protected set; }
 
         protected SQLExtConnection( AccessMode mode )


### PR DESCRIPTION
This adds preliminary support for specifying a custom connection in the app config

In its current state, it relies on the user having set up the database schema when the connection is overridden.