### PR TITLE
Speed up Point3D.X/Y/Z get/set

### DIFF
--- a/BaseUtilities/EMK/Point3D.cs
+++ b/BaseUtilities/EMK/Point3D.cs
@@ -52,24 +52,33 @@ namespace EMK.LightGeometry
 		/// <exception cref="IndexOutOfRangeException">Index must belong to [0;2].</exception>
 		public double this[int CoordinateIndex]
 		{
-			get { return _Coordinates[CoordinateIndex]; }
-			set	{ _Coordinates[CoordinateIndex] = value; }
+			get => _Coordinates[CoordinateIndex];
+			set => _Coordinates[CoordinateIndex] = value;
 		}
 
 		/// <summary>
 		/// Gets/Set X coordinate.
 		/// </summary>
-		public double X { set { _Coordinates[0] = value; } get { return _Coordinates[0]; } }
+		public double X {
+			set => _Coordinates[0] = value;
+			get => _Coordinates[0];
+		}
 
 		/// <summary>
 		/// Gets/Set Y coordinate.
 		/// </summary>
-		public double Y { set { _Coordinates[1] = value; } get { return _Coordinates[1]; } }
+		public double Y {
+			set => _Coordinates[1] = value;
+			get => _Coordinates[1];
+		}
 
 		/// <summary>
 		/// Gets/Set Z coordinate.
 		/// </summary>
-		public double Z { set { _Coordinates[2] = value; } get { return _Coordinates[2]; } }
+		public double Z {
+			set => _Coordinates[2] = value;
+			get => _Coordinates[2];
+		}
 
         /// <summary>
         /// Returns the distance between two points.

--- a/BaseUtilities/EMK/Vector3D.cs
+++ b/BaseUtilities/EMK/Vector3D.cs
@@ -62,24 +62,36 @@ namespace EMK.LightGeometry
         /// <exception cref="IndexOutOfRangeException">Illegal value for CoordinateIndex.</exception>
         public double this[int CoordinateIndex]
         {
-            get { return _Coordinates[CoordinateIndex]; }
-            set { _Coordinates[CoordinateIndex] = value; }
+            get => _Coordinates[CoordinateIndex];
+            set => _Coordinates[CoordinateIndex] = value;
         }
 
         /// <summary>
         /// Gets/Sets delta X value.
         /// </summary>
-        public double DX { set { _Coordinates[0] = value; } get { return _Coordinates[0]; } }
+        public double DX
+        {
+            set => _Coordinates[0] = value;
+            get => _Coordinates[0];
+        }
 
         /// <summary>
         /// Gets/Sets delta Y value.
         /// </summary>
-        public double DY { set { _Coordinates[1] = value; } get { return _Coordinates[1]; } }
+        public double DY
+        {
+            set => _Coordinates[1] = value;
+            get => _Coordinates[1];
+        }
 
         /// <summary>
         /// Gets/Sets delta Z value.
         /// </summary>
-        public double DZ { set { _Coordinates[2] = value; } get { return _Coordinates[2]; } }
+        public double DZ
+        {
+            set => _Coordinates[2] = value;
+            get => _Coordinates[2];
+        }
 
         /// <summary>
         /// Multiplication of a vector by a scalar value.
@@ -128,7 +140,7 @@ namespace EMK.LightGeometry
         /// <exception cref="InvalidOperationException">Vector's norm cannot be changed if it is 0.</exception>
         public double Norm
         {
-            get { return Math.Sqrt(SquareNorm); }
+            get => Math.Sqrt(SquareNorm);
             set
             {
                 double N = Norm;
@@ -181,13 +193,7 @@ namespace EMK.LightGeometry
             Z = z;
         }
 
-        public float LengthSquared
-        {
-            get
-            {
-                return X * X + Y * Y + Z * Z;
-            }
-        }
+        public float LengthSquared => X * X + Y * Y + Z * Z;
 
         public static Vector3 operator +(Vector3 a, Vector3 b)
         {


### PR DESCRIPTION
This PR improves the average time of the following loop by around **10%**.

Here is a small benchmark I wrote to accompany my above findings: https://github.com/EoD/EDDBenchmarks/blob/bc025004ea492b2cf01343baa30e2a8c1d0960fc/EDDBenchmarks/Point3DDistanceBenchmark.cs#L47-L70
Original:
```
Generating random Point3D list of size 25000
List generated, duration: 0.003s

Calculating distances
Total: 3.381957E+07, duration: 6.334s
Total: 3.381957E+07, duration: 6.198s
Total: 3.381957E+07, duration: 6.194s
Total: 3.381957E+07, duration: 6.185s
Total: 3.381957E+07, duration: 6.210s
```

With the patch around 10% faster
```
Generating random Point3D list of size 25000
List generated, duration: 0.002s

Calculating distances
Total: 3.38295E+07, duration: 5.646s
Total: 3.38295E+07, duration: 5.616s
Total: 3.38295E+07, duration: 5.614s
Total: 3.38295E+07, duration: 5.614s
Total: 3.38295E+07, duration: 5.641s
```

EDIT:
There is also a major performance difference with debugging enabled. The difference is **>400%**. 
These are screenshots from the dotTrace Profiler:

Original:
![dotTrace_before](https://user-images.githubusercontent.com/293499/67119858-4d1d8e00-f1e8-11e9-978b-48a82e5fc0f7.png)


After the changes:
![dotTrace_after](https://user-images.githubusercontent.com/293499/67119781-1e071c80-f1e8-11e9-9d70-727bb3d9700d.png)