### PR TITLE
Don't split WriteLine

### DIFF
--- a/BaseUtilities/DebugTraceAndLogs/TraceLog.cs
+++ b/BaseUtilities/DebugTraceAndLogs/TraceLog.cs
@@ -30,6 +30,7 @@ namespace BaseUtils
         public static string LogFileName { get; private set; }
         public static string LogFileBaseName { get; private set; }
         public static Thread LogFileWriterThread;
+        public static bool DisableLogDeduplication { get; set; }
         private static BlockingCollection<string> LogLineQueue = new BlockingCollection<string>();
         private static AutoResetEvent LogLineQueueEvent = new AutoResetEvent(false);
 
@@ -46,13 +47,17 @@ namespace BaseUtils
                 {
                     logline.Value.Append(value);
                     string logval = logline.ToString();
-                    while (logval.Contains("\n"))
+
+                    if (logval.Contains("\n"))
                     {
-                        string[] lines = logval.Split(new[] { '\n' }, 2);
-                        TraceLog.WriteLine(lines[0]);
                         logline.Value.Clear();
-                        logline.Value.Append(lines.Length == 2 ? lines[1] : "");
-                        logval = logline.ToString();
+                        var lastnewline = logval.LastIndexOf('\n');
+                        TraceLog.WriteLine(logval.Substring(0, lastnewline));
+                        if (lastnewline < logval.Length - 1)
+                        {
+                            logval = logval.Substring(lastnewline + 1);
+                            logline.Value.Append(logval);
+                        }
                     }
                 }
             }
@@ -112,16 +117,23 @@ namespace BaseUtils
                                     LogLineQueueEvent.Set();
                                     return;
                                 }
-                                else if (msgrepeats.ContainsKey(msg))
+                                else if (!DisableLogDeduplication && msgrepeats.ContainsKey(msg))
                                 {
                                     msgrepeats[msg]++;
                                 }
                                 else
                                 {
-                                    writer.WriteLine($"[{DateTime.UtcNow.ToStringZulu()}] {msg}");
+                                    var lines = msg.Split('\n');
+                                    var timestamp = DateTime.UtcNow.ToStringZulu();
+
+                                    foreach (var line in lines)
+                                    {
+                                        writer.WriteLine($"[{timestamp}] {line}");
+                                        linenum++;
+                                    }
+
                                     writer.Flush();
                                     msgrepeats[msg] = 0;
-                                    linenum++;
                                     if (linenum >= 100000)
                                     {
                                         partnum++;


### PR DESCRIPTION
* Add DisableLogDeduplication property to TraceLog
* Pass WriteLine blocks as a block to logger
* Deduplicate WriteLine blocks instead of lines

This should prevent stack traces and json dumps from being mangled.