### PR TITLE
Add support for switching DB to read-only with multithreading

### DIFF
--- a/SQLLite/SQLLite/SQLConnectionRegister.cs
+++ b/SQLLite/SQLLite/SQLConnectionRegister.cs
@@ -43,6 +43,11 @@ namespace SQLLiteExtensions
                 if (utctimeindicator)   // indicate treat dates as UTC.
                     connection.ConnectionString += "DateTimeKind=Utc;";
 
+                if (mode == AccessMode.Reader)
+                {
+                    connection.ConnectionString += "Read Only=True;";
+                }
+
                 // System.Diagnostics.Debug.WriteLine("Created connection " + connection.ConnectionString);
 
                 connection.Open();


### PR DESCRIPTION
This still runs the SQL queries in their own threads, but once switched to read-only mode will allow multiple concurrent queries.