### PR TITLE
Ignore WebBrowser COM exceptions

### DIFF
--- a/BaseUtilities/DebugTraceAndLogs/ExceptionCatcher.cs
+++ b/BaseUtilities/DebugTraceAndLogs/ExceptionCatcher.cs
@@ -58,6 +58,13 @@ namespace BaseUtils
             try
             {
                 TraceLog.WriteLine($"\n==== UNHANDLED UI EXCEPTION ====\n{e.Exception.ToString()}\n==== cut ====");
+
+                // Ignore COM exceptions in Web Browser component
+                if (e.Exception is System.Runtime.InteropServices.COMException && e.Exception.StackTrace.Contains("System.Windows.Forms.UnsafeNativeMethods.IWebBrowser2.Navigate2"))
+                {
+                    return;
+                }
+
                 ExceptionForm.ShowException(e.Exception, "There was an unhandled UI exception.", urlfeedback);
             }
             catch


### PR DESCRIPTION
It appears that the EDSM page ad trying to refresh might be causing an unhandled COM exception that we can't catch (no EDDiscovery methods are in the call stack) - see EDDiscovery/EDDiscovery#2862

Log the exception and don't show the unhandled UI exception window.