### PR TITLE
Throw an exception on parse error by default

### DIFF
--- a/BaseUtilities/BaseUtils.csproj
+++ b/BaseUtilities/BaseUtils.csproj
@@ -68,6 +68,7 @@
     <Compile Include="IconSet\IconGroup.cs" />
     <Compile Include="IconSet\IconSet.cs" />
     <Compile Include="IconSet\IIconSet.cs" />
+    <Compile Include="JSON\JsonException.cs" />
     <Compile Include="JSON\QuickJSON.cs" />
     <Compile Include="JSON\QuickJSONObject.cs" />
     <Compile Include="JSON\QuickJSONArray.cs" />

--- a/BaseUtilities/JSON/JsonException.cs
+++ b/BaseUtilities/JSON/JsonException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BaseUtils.JSON
+{
+    public class JsonException : InvalidOperationException
+    {
+        public string JSON { get; set; }
+        public int Offset { get; set; }
+
+        public JsonException(string json, int offset, string message) : base(message)
+        {
+            JSON = json;
+            Offset = offset;
+        }
+    }
+}

--- a/BaseUtilities/JSON/QuickJSONParse.cs
+++ b/BaseUtilities/JSON/QuickJSONParse.cs
@@ -29,7 +29,7 @@ namespace BaseUtils.JSON
             None = 0,
             AllowTrailingCommas = 1,
             CheckEOL = 2,
-            NoThrow = 4,
+            Throw = 4,
         }
 
         public static JToken Parse(string s, ParseOptions flags = ParseOptions.None)        // null if failed - must not be extra text
@@ -339,13 +339,13 @@ namespace BaseUtils.JSON
                             + parser.Line.Substring(parser.Position);
             System.Diagnostics.Debug.WriteLine(s);
 
-            if (options.HasFlag(ParseOptions.NoThrow))
+            if (options.HasFlag(ParseOptions.Throw))
             {
-                return s;
+                throw new JsonException(parser.Line, parser.Position, s);
             }
             else
             {
-                throw new JsonException(parser.Line, parser.Position, s);
+                return s;
             }
         }
     }

--- a/BaseUtilities/JSON/QuickJSONTokenReader.cs
+++ b/BaseUtilities/JSON/QuickJSONTokenReader.cs
@@ -63,7 +63,7 @@ namespace BaseUtils.JSON
 
                 if (o == null)
                 {
-                    throw new TokenException(GenError(parser, "No Obj/Array"));
+                    throw new TokenException(GenError(parser, "No Obj/Array", ParseOptions.NoThrow));
                 }
                 else if (o.TokenType == JToken.TType.Array)
                 {
@@ -98,7 +98,7 @@ namespace BaseUtils.JSON
 
                             if (comma == true && (flags & JToken.ParseOptions.AllowTrailingCommas) == 0)
                             {
-                                throw new TokenException(GenError(parser, "Comma"));
+                                throw new TokenException(GenError(parser, "Comma", ParseOptions.NoThrow));
                             }
                             else
                             {
@@ -127,7 +127,7 @@ namespace BaseUtils.JSON
 
                             if (textlen < 1 || (comma == false && curobject.Count > 0) || !parser.IsCharMoveOn(':'))
                             {
-                                throw new TokenException(GenError(parser, "Object missing property name"));
+                                throw new TokenException(GenError(parser, "Object missing property name", ParseOptions.NoThrow));
                             }
                             else
                             {
@@ -137,7 +137,7 @@ namespace BaseUtils.JSON
 
                                 if (o == null)
                                 {
-                                    throw new TokenException(GenError(parser, "Object bad value"));
+                                    throw new TokenException(GenError(parser, "Object bad value", ParseOptions.NoThrow));
                                 }
 
                                 o.Name = name;
@@ -148,7 +148,7 @@ namespace BaseUtils.JSON
                                 {
                                     if (sptr == stack.Length - 1)
                                     {
-                                        throw new TokenException(GenError(parser, "Stack overflow"));
+                                        throw new TokenException(GenError(parser, "Stack overflow", ParseOptions.NoThrow));
                                     }
 
                                     stack[++sptr] = o;          // push this one onto stack
@@ -161,7 +161,7 @@ namespace BaseUtils.JSON
                                 {
                                     if (sptr == stack.Length - 1)
                                     {
-                                        throw new TokenException(GenError(parser, "Stack overflow"));
+                                        throw new TokenException(GenError(parser, "Stack overflow", ParseOptions.NoThrow));
                                     }
 
                                     stack[++sptr] = o;          // push this one onto stack
@@ -176,7 +176,7 @@ namespace BaseUtils.JSON
                         }
                         else
                         {
-                            throw new TokenException(GenError(parser, "Bad format in object"));
+                            throw new TokenException(GenError(parser, "Bad format in object", ParseOptions.NoThrow));
                         }
                     }
                 }
@@ -188,13 +188,13 @@ namespace BaseUtils.JSON
 
                         if (o == null)
                         {
-                            throw new TokenException(GenError(parser, "Bad array value"));
+                            throw new TokenException(GenError(parser, "Bad array value", ParseOptions.NoThrow));
                         }
                         else if (o.TokenType == JToken.TType.EndArray)          // if end marker, jump back
                         {
                             if (comma == true && (flags & JToken.ParseOptions.AllowTrailingCommas) == 0)
                             {
-                                throw new TokenException(GenError(parser, "Comma"));
+                                throw new TokenException(GenError(parser, "Comma", ParseOptions.NoThrow));
                             }
                             else
                             {
@@ -220,7 +220,7 @@ namespace BaseUtils.JSON
                         }
                         else if ((comma == false && curarray.Count > 0))   // missing comma
                         {
-                            throw new TokenException(GenError(parser, "Comma"));
+                            throw new TokenException(GenError(parser, "Comma", ParseOptions.NoThrow));
                         }
                         else
                         {
@@ -230,7 +230,7 @@ namespace BaseUtils.JSON
                             {
                                 if (sptr == stack.Length - 1)
                                 {
-                                    throw new TokenException(GenError(parser, "Stack overflow"));
+                                    throw new TokenException(GenError(parser, "Stack overflow", ParseOptions.NoThrow));
                                 }
 
                                 stack[++sptr] = o;              // push this one onto stack
@@ -241,7 +241,7 @@ namespace BaseUtils.JSON
                             {
                                 if (sptr == stack.Length - 1)
                                 {
-                                    throw new TokenException(GenError(parser, "Stack overflow"));
+                                    throw new TokenException(GenError(parser, "Stack overflow", ParseOptions.NoThrow));
                                 }
 
                                 stack[++sptr] = o;              // push this one onto stack


### PR DESCRIPTION
A parse error is exceptional, and should throw an exception except in the exceptional case that it is requested not to throw an exception.

Returning null instead of throwing an exception kicks the error down the road where the errors can be harder to diagnose.