### PR TITLE
Fix favicon.ico not being treated as a binary when served from eddwebsite.zip

### DIFF
--- a/BaseUtilities/WebServer/WebServerZipNode.cs
+++ b/BaseUtilities/WebServer/WebServerZipNode.cs
@@ -24,7 +24,7 @@ namespace BaseUtils.WebServer
 {
     public class HTTPZipNode : IHTTPNode
     {
-        public string[] BinaryTypes = new string[] { ".png", ".bmp" };
+        public string[] BinaryTypes = new string[] { ".png", ".bmp", ".ico", ".jpg" , ".jpeg", ".tif", ".tiff", ".gif" , ".raw", ".eps" };
 
         private string path;
 


### PR DESCRIPTION
While this was fixed for the serve-from-directory use case a while ago, `favicon.ico` is still interpreted as text when served from the `eddwebsite.zip`. This PR should fix this.