### PR TITLE
Fix compile error under mono due to missing references to netstandard libraries

### DIFF
--- a/Audio/Audio.csproj
+++ b/Audio/Audio.csproj
@@ -72,6 +72,12 @@
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">
       <Version>10.0.26100.4188</Version>
     </PackageReference>
+    <PackageReference Include="NETStandard.Library">
+      <Version>2.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime">
+      <Version>4.3.1</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Working AppVeyor build: https://ci.appveyor.com/project/klightspeed/eddiscovery/builds/52235806